### PR TITLE
Test dynamic install

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TEST_PSC_FP="/Pysces/psc/BIOMD0000000012_url.xml.psc" \
     TEST_OMEX_FP="test-fixtures/sbml-core/Elowitz-Nature-2000-Repressilator.omex"
 
-# copy docker
+# copy docker assets
 COPY assets/docker/config/.biosimulations.json /.google/.bio-check.json
 COPY assets/docker/config/.pys_usercfg.ini /Pysces/.pys_usercfg.ini
 COPY assets/docker/config/.pys_usercfg.ini /root/Pysces/.pys_usercfg.ini

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,5 +1,7 @@
-# FROM ubuntu:22.04
-FROM continuumio/miniconda3:main
+# FROM ubuntu:22.04  <-- heavy out of the box, substantially heavier after build
+# FROM continuumio/miniconda3:main  <-- issues with liscening/debian-only(not ubuntu)
+
+FROM condaforge/miniforge-pypy3:24.9.0-0
 
 LABEL org.opencontainers.image.title="bio-compose-server-base" \
     org.opencontainers.image.description="Base Docker image for BioCompose REST API management, job processing, and datastorage with MongoDB, ensuring scalable and robust performance." \

--- a/kustomize/config/biochecknet/shared.env
+++ b/kustomize/config/biochecknet/shared.env
@@ -1,5 +1,5 @@
 MONGO_URI=mongodb://mongodb/?retryWrites=true&w=majority&appName=bio-check
-# MONGO_URI=mongodb://alex:123@mongodb:27017/service_requests?retryWrites=true&w=majority&appName=bio-check
+# MONGO_URI=mongodb://mongodb:27017/service_requests?retryWrites=true&w=majority&appName=bio-check
 MONGO_DB_USERNAME=alex
 MONGO_DB_PWD=123
 DB_NAME=service_requests

--- a/worker/Dockerfile-worker
+++ b/worker/Dockerfile-worker
@@ -10,7 +10,49 @@ SHELL ["/usr/bin/env", "bash", "-c"]
 
 COPY . .
 
+ENV MONGO_URI=mongodb://mongodb/service_requests
+
 # TODO: separate these into blocks by dep, then use that block in the dynamic_install
+# RUN source ~/.bashrc \
+#     && apt-get update  \
+#     && apt install -y \
+#     meson \
+#     g++ \
+#     gfortran \
+#     libblas-dev \
+#     liblapack-dev \
+#     libgfortran5 \
+#     libhdf5-dev \
+#     libhdf5-serial-dev \
+#     libatlas-base-dev \
+#     cmake \
+#     make \
+#     git \
+#     build-essential \
+#     python3-dev \
+#     swig \
+#     libc6-dev \
+#     libx11-dev \
+#     libc6 \
+#     libgl1-mesa-dev \
+#     pkg-config \
+#     curl \
+#     tar \
+#     libgl1-mesa-glx \
+#     libice6 \
+#     libsm6 \
+#     gnupg \
+#     libboost-chrono-dev \
+#     libboost-math-dev \
+#     libboost-serialization-dev \
+#     && conda env update -n server -f environment.worker.yml \
+#     && conda env export --no-builds > config/environment.worker.lock.yml \
+#     && conda clean -t -l --json -y \
+#     && rm -f environment.worker.yml \
+#     && rm -rf /var/lib/apt/lists/* \
+#     && apt-get autoremove -y \
+#     && apt-get clean
+
 RUN source ~/.bashrc \
     && apt-get update  \
     && apt install -y \
@@ -43,15 +85,13 @@ RUN source ~/.bashrc \
     libboost-chrono-dev \
     libboost-math-dev \
     libboost-serialization-dev \
-    && conda env update -n server -f environment.worker.yml \
-    && conda env export --no-builds > config/environment.worker.lock.yml \
     && conda clean -t -l --json -y \
-    && rm -f environment.worker.yml \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \
-    && apt-get clean
+    && apt-get clean \
+    && chmod +x ./dynamic_install.sh
 
-ENTRYPOINT ["bash", "-c", "source ~/.bashrc && conda run -n server python3 main.py"]
+# ENTRYPOINT ["bash", "-c", "source ~/.bashrc && conda run -n server python3 main.py"]
 
 
 #############################

--- a/worker/Dockerfile-worker
+++ b/worker/Dockerfile-worker
@@ -93,7 +93,7 @@ RUN source ~/.bashrc \
     && chmod +x ./dynamic_install.sh
 
 # ENTRYPOINT ["bash", "-c", "source ~/.bashrc && conda run -n server python3 main.py"]
-
+ENTRYPOINT ["bash", "-c", "source ~/.bashrc && ./dynamic_install.sh"]
 
 #############################
 # Fenics installation

--- a/worker/Dockerfile-worker
+++ b/worker/Dockerfile-worker
@@ -85,6 +85,7 @@ RUN source ~/.bashrc \
     libboost-chrono-dev \
     libboost-math-dev \
     libboost-serialization-dev \
+    && conda run -n server pip3 install simulariumio process-bigraph h5py biosimulators-utils[logging] python-libsbml \
     && conda clean -t -l --json -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \

--- a/worker/Dockerfile-worker
+++ b/worker/Dockerfile-worker
@@ -10,7 +10,7 @@ SHELL ["/usr/bin/env", "bash", "-c"]
 
 COPY . .
 
-# TODO: perhaps run --no-install-recommends?
+# TODO: separate these into blocks by dep, then use that block in the dynamic_install
 RUN source ~/.bashrc \
     && apt-get update  \
     && apt install -y \

--- a/worker/data_generator.py
+++ b/worker/data_generator.py
@@ -312,7 +312,7 @@ def run_sbml_tellurium(sbml_fp: str, start, dur, steps):
         return {"error": error_message}
 
 
-def run_sbml_copasi(sbml_fp, start, dur, steps):
+def run_sbml_copasi(sbml_fp: str, start: int, dur: int, steps: int) -> dict[str, list[float]]:
     try:
         t = np.linspace(start, dur, steps + 1)
         model = load_model(sbml_fp)

--- a/worker/dynamic_install.sh
+++ b/worker/dynamic_install.sh
@@ -3,10 +3,10 @@
 # num_simulators=$(poetry run python3 -c "print(len($simulators))")
 
 while true; do
-  INPUT_FORMAT=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('path').split('/')[-1]")
-  SIMULATORS=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('simulators'))")
+  INPUT_FORMAT=$(conda run -n server python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('path').split('/')[-1])")
+  SIMULATORS=$(conda run -n server python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('simulators'))")
   SIMULATORS=$(echo "$SIMULATORS" | tr -d "[]' ")
-  JOB_ID=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('job_id'))")
+  JOB_ID=$(conda run -n server python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('job_id'))")
   IFS=','
 
   # create dynamic environment
@@ -15,15 +15,13 @@ while true; do
   # install each specified simulator
   for sim in $SIMULATORS; do
     pkg="$sim"
-    if [ "$INPUT_FORMAT" == ".omex" ]; then
-      pkg=biosimulators-"$pkg"
-    fi
-
-    if [ "$sim" == "pysces" ]; then
+    # if [ "$INPUT_FORMAT" == ".omex" ]; then
+    #   pkg=biosimulators-"$pkg"
+    # fi
+    if [ "$sim" == pysces ]; then
       conda install -n "$JOB_ID" -c conda-forge -c pysces pysces
     fi
-
-    conda run -n "$JOB_ID" pip3 install "$pkg"
+    conda run -n "$JOB_ID" pip3 install $pkg
   done
   break
 

--- a/worker/dynamic_install.sh
+++ b/worker/dynamic_install.sh
@@ -11,7 +11,7 @@ while true; do
 
   # create dynamic environment
   conda create -n "$JOB_ID" python=3.10 -y
-
+  conda run -n "$JOB_ID" pip3 install process-bigraph uvicorn typing-extension pyyaml uvicorn pydantic pydantic-settings google-cloud-storage pymongo python-dotenv fastapi requests-toolbelt
   # install each specified simulator
   for sim in $SIMULATORS; do
     pkg="$sim"
@@ -25,6 +25,7 @@ while true; do
 
     conda run -n "$JOB_ID" pip3 install "$pkg"
   done
+  break
 
   # TODO:
   # 1. in base, upgrade base conda pip but do NOT create env

--- a/worker/dynamic_install.sh
+++ b/worker/dynamic_install.sh
@@ -2,36 +2,38 @@
 
 # num_simulators=$(poetry run python3 -c "print(len($simulators))")
 
-INPUT_FORMAT=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('path').split('/')[-1]")
-SIMULATORS=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('simulators'))")
-SIMULATORS=$(echo "$SIMULATORS" | tr -d "[]' ")
-JOB_ID=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('job_id'))")
-IFS=','
+while true; do
+  INPUT_FORMAT=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('path').split('/')[-1]")
+  SIMULATORS=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('simulators'))")
+  SIMULATORS=$(echo "$SIMULATORS" | tr -d "[]' ")
+  JOB_ID=$(poetry run python3 -c "from main import db_connector;print(db_connector.pending_jobs()[0].get('job_id'))")
+  IFS=','
 
-# create dynamic environment
-conda create -n "$JOB_ID" python=3.10 -y
+  # create dynamic environment
+  conda create -n "$JOB_ID" python=3.10 -y
 
-# install each specified simulator
-for sim in $SIMULATORS; do
-  pkg="$sim"
-  if [ "$INPUT_FORMAT" == ".omex" ]; then
-    pkg=biosimulators-"$pkg"
-  fi
+  # install each specified simulator
+  for sim in $SIMULATORS; do
+    pkg="$sim"
+    if [ "$INPUT_FORMAT" == ".omex" ]; then
+      pkg=biosimulators-"$pkg"
+    fi
 
-  if [ "$sim" == "pysces" ]; then
-    conda install -n "$JOB_ID" -c conda-forge -c pysces pysces
-  fi
+    if [ "$sim" == "pysces" ]; then
+      conda install -n "$JOB_ID" -c conda-forge -c pysces pysces
+    fi
 
-  conda run -n "$JOB_ID" pip3 install "$pkg"
+    conda run -n "$JOB_ID" pip3 install "$pkg"
+  done
+
+  # TODO:
+  # 1. in base, upgrade base conda pip but do NOT create env
+  # 2. in api, install BASE requirements(mostly api anyway!)
+  # 3. in worker run script, get simulators and req input format and create env indexed by job_id from BASE requirements
+  # 4. For each requested simulator, dynamically install into existing base
+  # 5. Run main.py but instead of while loop, let it run just for the single job.
+  # 6. Db is already updated with results after number 5, so run conda env remove -n "$JOB_ID" -y
 done
-
-# TODO:
-# 1. in base, upgrade base conda pip but do NOT create env
-# 2. in api, install BASE requirements(mostly api anyway!)
-# 3. in worker run script, get simulators and req input format and create env indexed by job_id from BASE requirements
-# 4. For each requested simulator, dynamically install into existing base
-# 5. Run main.py but instead of while loop, let it run just for the single job.
-# 6. Db is already updated with results after number 5, so run conda env remove -n "$JOB_ID" -y
 
 
 

--- a/worker/environment.worker.yml
+++ b/worker/environment.worker.yml
@@ -11,9 +11,6 @@ dependencies:
   - pysces
   - pymem3dg
   - pip:
-      - copasi-basico
-      - tellurium
-      - amici
       - h5py
       - process-bigraph
       - simulariumio
@@ -22,4 +19,7 @@ dependencies:
       - biosimulators-copasi
       - biosimulators-tellurium
       - biosimulators-pysces
+      - copasi-basico
+      - tellurium
+      - amici
 prefix: /opt/conda/envs/server

--- a/worker/shared_worker.py
+++ b/worker/shared_worker.py
@@ -8,7 +8,6 @@ from enum import Enum
 from typing import *
 
 from dotenv import load_dotenv
-from process_bigraph import ProcessTypes
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.database import Database
@@ -23,7 +22,6 @@ load_dotenv('../assets/dev/config/.env_dev')
 DB_TYPE = "mongo"  # ie: postgres, etc
 DB_NAME = "service_requests"
 BUCKET_NAME = os.getenv("BUCKET_NAME")
-PROCESS_TYPES = ProcessTypes()  # CORE
 
 
 # -- shared functions -- #

--- a/worker/startup.py
+++ b/worker/startup.py
@@ -1,0 +1,31 @@
+import os
+import asyncio
+
+from shared_worker import MongoDbConnector
+
+
+def __run_startup():
+    db_connector = MongoDbConnector(connection_uri=os.environ['MONGO_URI'], database_id='service_requests')
+
+    test_entry1 = {
+        'job_id': 'test-entry1',
+        'simulators': ['amici', 'copasi', 'pysces', 'tellurium']
+    }
+
+    test_entry2 = {
+        'job_id': 'test-entry2',
+        'simulators': ['smoldyn']
+    }
+
+    asyncio.run(db_connector.write(
+        collection_name='pending_jobs',
+        **test_entry1
+    ))
+
+    asyncio.run(db_connector.write(
+        collection_name='pending_jobs',
+        **test_entry2
+    ))
+
+
+__run_startup()


### PR DESCRIPTION
_What does this PR do?:_
- Adds an experimental `worker/dynamic_install.sh` for custom ephemeral `conda` environments based on the needs of a given incoming simulation/verification request.
- Updates base environment to use `condaforge/miniforge-pypy3:24.9.0-0` instead of `continuumio/miniconda3:main` for the value of `FROM` within `./Dockerfile-base`. 
- Re-implements and thereby keeps the option of `poetry` dependency management rather than `conda`.
- Adds more tests to both `./api` and `./worker` content.